### PR TITLE
Fix issue #18: Filter out virtual/auto-generated network interfaces

### DIFF
--- a/device.go
+++ b/device.go
@@ -7,6 +7,36 @@ import (
 	"strings"
 )
 
+// isVirtualInterface checks if an interface is virtual/auto-generated
+func isVirtualInterface(name string) bool {
+	// Common virtual interface prefixes across different systems
+	virtualPrefixes := []string{
+		"utun",     // macOS VPN tunnels
+		"awdl",     // macOS Apple Wireless Direct Link
+		"llw",      // macOS Low latency WLAN interface
+		"bridge",   // Bridge interfaces
+		"veth",     // Linux virtual ethernet (Docker)
+		"docker",   // Docker interfaces
+		"virbr",    // Virtual bridge (libvirt)
+		"vnet",     // Virtual network interfaces
+		"tap",      // TAP interfaces
+		"tun",      // TUN interfaces (generic)
+		"gif",      // Generic tunnel interface
+		"stf",      // 6to4 tunnel interface
+		"anpi",     // macOS internal interfaces
+		"ap",       // macOS access point interface
+	}
+
+	// Check if the interface starts with any virtual prefix
+	for _, prefix := range virtualPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func checkDevice() {
 	fmt.Println("🖥️  Device/Interface Information")
 	fmt.Println("==============================")
@@ -54,6 +84,10 @@ func getNetworkInterfaces() []string {
 	ifaces, err := net.Interfaces()
 	if err == nil {
 		for _, iface := range ifaces {
+			// Skip virtual interfaces unless --show-virtual flag is set
+			if !*showVirtualFlag && isVirtualInterface(iface.Name) {
+				continue
+			}
 			var status string
 			if iface.Flags&net.FlagUp != 0 {
 				status = "UP"

--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ var (
 
 	// Global configuration flags
 	timeoutFlag    = flag.Duration("timeout", 60*time.Second, "Maximum time to run all tests (e.g. 30s, 2m, 1h)")
+	showVirtualFlag  = flag.Bool("show-virtual", false, "Show virtual network interfaces (VPN tunnels, Docker bridges, etc.)")
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Add `--show-virtual` flag to optionally display virtual network interfaces
- Filter out common virtual interfaces by default (utun, veth, docker, bridge, etc.)
- Reduces output clutter by hiding VPN tunnels, Docker bridges, and other auto-generated interfaces

## Changes
- Added `isVirtualInterface()` function to identify virtual/auto-generated interfaces
- Modified `getNetworkInterfaces()` to skip virtual interfaces by default
- Added `--show-virtual` flag to restore previous behavior when needed

## Testing
- Verified that virtual interfaces are hidden by default
- Confirmed `--show-virtual` flag shows all interfaces
- Build passes without errors

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)