### PR TITLE
Fix issue #17: Reduce timeout for port scanning on locked down networks

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ const (
 // Common timeouts
 const (
 	HTTPTimeout   = 5 * time.Second
-	PortTimeout   = 2 * time.Second
+	PortTimeout   = 1 * time.Second  // Reduced from 2s for faster scanning on restricted networks
 	NATpmpTimeout = 3 * time.Second
 )
 
@@ -120,6 +120,7 @@ var (
 	// Global configuration flags
 	timeoutFlag    = flag.Duration("timeout", 60*time.Second, "Maximum time to run all tests (e.g. 30s, 2m, 1h)")
 	showVirtualFlag  = flag.Bool("show-virtual", false, "Show virtual network interfaces (VPN tunnels, Docker bridges, etc.)")
+	portTimeoutFlag = flag.Duration("port-timeout", PortTimeout, "Timeout for individual port scans (e.g. 500ms, 1s, 2s)")
 )
 
 func main() {
@@ -420,7 +421,7 @@ func scanCommonPorts(router *RouterInfo) {
 }
 
 func isPortOpen(ip string, port int) bool {
-	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, strconv.Itoa(port)), PortTimeout)
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(ip, strconv.Itoa(port)), *portTimeoutFlag)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
## Summary
- Reduce default port scan timeout from 2s to 1s for faster scanning
- Add `--port-timeout` flag to allow customization of the timeout
- Prevents hanging on restricted guest networks where ports are blocked

## Changes
- Changed `PortTimeout` constant from 2s to 1s
- Added `--port-timeout` flag with customizable duration (e.g., 500ms, 1s, 2s)
- Modified `isPortOpen()` to use the flag value instead of the constant

## Testing
- Verified port scanning completes faster on restricted networks
- Confirmed custom timeout values work with `--port-timeout` flag
- Build passes without errors

Fixes #17

🤖 Generated with [Claude Code](https://claude.ai/code)